### PR TITLE
Orders show

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,8 @@ class Order < ApplicationRecord
   enum status: ['pending', 'packaged', 'shipped', 'cancelled']
 
   def grand_total
-    order_items.sum('price * quantity')
+    # order_items.sum('price * quantity')
+    order_items.sum(&:subtotal)
   end
 
   def count_of_items

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -3,7 +3,12 @@ class OrderItem < ApplicationRecord
   belongs_to :item
 
   def subtotal
-    quantity * price
+    # quantity * price
+    if get_discount
+      discounted_subtotal
+    else
+      quantity * price
+    end
   end
 
   def fulfill
@@ -13,5 +18,21 @@ class OrderItem < ApplicationRecord
 
   def fulfillable?
     item.inventory >= quantity
+  end
+
+  def discounted_subtotal
+    discount = discount_percentage.fdiv(100)
+    subtotal = self.quantity * Item.find(item_id).price
+    subtotal -= discount * subtotal
+    subtotal.round(2)
+  end
+
+  def get_discount
+    item = Item.find(self.item_id)
+    item.merchant.discounts.where(item_minimum: self.quantity).order('percent desc').first
+  end
+
+  def discount_percentage
+    self.get_discount.percent
   end
 end

--- a/app/views/merchant/discounts/index.html.erb
+++ b/app/views/merchant/discounts/index.html.erb
@@ -4,7 +4,7 @@
 <% if @discounts.count > 0 %>
   <% @discounts.each do |discount| %>
     <h3><%= link_to discount.name, "/merchant/discounts/#{discount.id}" %></h3>
-    <p><%= discount.percent %> off for <%= discount.item_minimum %> items.</p>
+    <p><%= discount.percent %>% off for <%= discount.item_minimum %> items.</p>
   <% end %>
 <% else %>
   <p>You have no discounts available</p>

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,19 +1,19 @@
 <h2>Edit Item</h2>
 <%= form_tag "/merchant/items/#{@item.id}", method: :patch do %>
   <%= label_tag :name %>
-  <%= text_field_tag :name %>
+  <%= text_field_tag :name, @item.name %>
 
   <%= label_tag :description %>
-  <%= text_field_tag :description %>
+  <%= text_field_tag :description, @item.description %>
 
   <%= label_tag :price %>
-  <%= text_field_tag :price %>
+  <%= text_field_tag :price, @item.price %>
 
   <%= label_tag :image %>
-  <%= text_field_tag :image %>
+  <%= text_field_tag :image, @item.image %>
 
   <%= label_tag :inventory %>
-  <%= text_field_tag :inventory %>
+  <%= text_field_tag :inventory, @item.inventory %>
 
   <%= submit_tag 'Update Item' %>
 <% end %>

--- a/spec/features/merchant/edit_item_spec.rb
+++ b/spec/features/merchant/edit_item_spec.rb
@@ -47,13 +47,11 @@ RSpec.describe 'Update Item Page' do
 
       visit "merchant/items/#{@ogre.id}/edit"
 
-      fill_in 'Name', with: name
+      fill_in 'Name', with: nil
       click_button 'Update Item'
 
-      expect(page).to have_content("description: [\"can't be blank\"]")
-      expect(page).to have_content("price: [\"can't be blank\"]")
-      expect(page).to have_content("image: [\"can't be blank\"]")
-      expect(page).to have_content("inventory: [\"can't be blank\"]")
+      expect(page).to have_content("name: [\"can't be blank\"]")
+
       expect(page).to have_button('Update Item')
     end
   end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -40,5 +40,31 @@ RSpec.describe OrderItem do
       expect(@order_item_1.fulfilled).to eq(true)
       expect(@ogre.inventory).to eq(3)
     end
+
+    it '.subtotal & .discounted_subtotal' do
+      @order_item_1.update(quantity: 5)
+      expect(@order_item_1.subtotal).to eq(101.25)
+
+      five_five = Discount.create!(name: 'Five on Five', item_minimum: 5, percent: 5, merchant_id: @megan.id)
+
+      expect(@order_item_1.discounted_subtotal).to eq(96.19)
+      expect(@order_item_1.subtotal).to eq(96.19)
+    end
+
+    it '.get_discount' do
+      five_five = Discount.create!(name: 'Five on Five', item_minimum: 5, percent: 5, merchant_id: @megan.id)
+
+      @order_item_1.update(quantity: 5)
+
+      expect(@order_item_1.get_discount).to eq(five_five)
+    end
+
+    it '.discount_percentage' do
+      five_five = Discount.create!(name: 'Five on Five', item_minimum: 5, percent: 5, merchant_id: @megan.id)
+
+      @order_item_1.update(quantity: 5)
+
+      expect(@order_item_1.discount_percentage).to eq(5)
+    end
   end
 end


### PR DESCRIPTION
Make sure that throughout the orders show pages, `subtotal` and `grand_total` accurately reflect existing discounts.

To assure this, I added 3 new instance methods to the `order_item` model that closely map to the new methods on `Cart`. Couldn't re-use, because the cart methods account for cart activity before that content has been turned into an order.